### PR TITLE
Add unit tests for ImageValidator: validate content types and handle …

### DIFF
--- a/core/src/test/java/greencity/validator/ImageValidatorTest.java
+++ b/core/src/test/java/greencity/validator/ImageValidatorTest.java
@@ -1,5 +1,6 @@
 package greencity.validator;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -11,10 +12,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ImageValidatorTest {
 
+    private ImageValidator imageValidator;
+
+    @BeforeEach
+    void setUp(){
+        imageValidator = new ImageValidator();
+    }
+
+
     @ParameterizedTest
     @ValueSource(strings = {"image/jpeg", "image/png", "image/jpg"})
     void isValidImageFileShouldContainsContentType(String contentType) {
-        ImageValidator imageValidator = new ImageValidator();
         MultipartFile multipartFile = new MockMultipartFile("file", "test.jpg", contentType, new byte[]{1, 2, 3, 4, 5});
 
         assertTrue(imageValidator.isValid(multipartFile, null));
@@ -22,10 +30,10 @@ class ImageValidatorTest {
 
     @Test
     void isValidImageFileShouldReturnTrueWhenFileIsNull() {
-        ImageValidator imageValidator = new ImageValidator();
         MultipartFile multipartFileIsNull = Mockito.mock(MultipartFile.class);
-
         Mockito.when(multipartFileIsNull.getContentType()).thenReturn(null);
+        Mockito.when(multipartFileIsNull.isEmpty()).thenReturn(true);
+
         assertFalse(imageValidator.isValid(multipartFileIsNull, null));
     }
 }

--- a/core/src/test/java/greencity/validator/ImageValidatorTest.java
+++ b/core/src/test/java/greencity/validator/ImageValidatorTest.java
@@ -1,0 +1,31 @@
+package greencity.validator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImageValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/jpeg", "image/png", "image/jpg"})
+    void isValidImageFileShouldContainsContentType(String contentType) {
+        ImageValidator imageValidator = new ImageValidator();
+        MultipartFile multipartFile = new MockMultipartFile("file", "test.jpg", contentType, new byte[]{1, 2, 3, 4, 5});
+
+        assertTrue(imageValidator.isValid(multipartFile, null));
+    }
+
+    @Test
+    void isValidImageFileShouldReturnTrueWhenFileIsNull() {
+        ImageValidator imageValidator = new ImageValidator();
+        MultipartFile multipartFileIsNull = Mockito.mock(MultipartFile.class);
+
+        Mockito.when(multipartFileIsNull.getContentType()).thenReturn(null);
+        assertFalse(imageValidator.isValid(multipartFileIsNull, null));
+    }
+}


### PR DESCRIPTION
Added parameterized test isValidImageFileShouldContainsContentType to validate supported image content types (image/jpeg, image/png, image/jpg).
Implemented test isValidImageFileShouldReturnTrueWhenFileIsNull to ensure that ImageValidator correctly handles null content types using a mocked MultipartFile.