### PR TITLE
Add custom validation for event dates to ensure finishDate is after startDate

### DIFF
--- a/service-api/src/main/java/greencity/annotations/ValidDates.java
+++ b/service-api/src/main/java/greencity/annotations/ValidDates.java
@@ -1,0 +1,16 @@
+package greencity.annotations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = greencity.validator.DatesValidator.class)
+@Documented
+public @interface ValidDates {
+    String message() default "Finish date must not be earlier than start date";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/service-api/src/main/java/greencity/dto/event/DatesLocationsDto.java
+++ b/service-api/src/main/java/greencity/dto/event/DatesLocationsDto.java
@@ -1,5 +1,6 @@
 package greencity.dto.event;
 
+import greencity.annotations.ValidDates;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
@@ -8,6 +9,7 @@ import lombok.*;
 
 import java.time.ZonedDateTime;
 
+@ValidDates
 @Getter
 @Setter
 @NoArgsConstructor

--- a/service-api/src/main/java/greencity/validator/DatesValidator.java
+++ b/service-api/src/main/java/greencity/validator/DatesValidator.java
@@ -1,0 +1,19 @@
+package greencity.validator;
+
+import greencity.annotations.ValidDates;
+import greencity.dto.event.DatesLocationsDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class DatesValidator implements ConstraintValidator<ValidDates, DatesLocationsDto> {
+    @Override
+    public void initialize(ValidDates constraintAnnotation) {
+    }
+    @Override
+    public boolean isValid(DatesLocationsDto dto, ConstraintValidatorContext context) {
+        if (dto.getStartDate() == null || dto.getFinishDate() == null) {
+            return true;
+        }
+        return !dto.getFinishDate().isBefore(dto.getStartDate());
+    }
+}


### PR DESCRIPTION
- Implemented @ValidDates annotation to validate that finishDate is not earlier than startDate in DatesLocationsDto
- Created DatesValidator to handle custom validation logic
- Applied @ValidDates annotation to DatesLocationsDto for automatic validation
- Updated controller to ensure event creation adheres to date constraints